### PR TITLE
Fix encoding and add Ice secret support

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -40,6 +40,9 @@ idata.properties = props
 # Create Ice connection
 ice = Ice.initialize(idata)
 proxy = ice.stringToProxy(settings.ICE_HOST.encode('ascii'))
+secret = settings.ICE_SECRET.encode('ascii')
+if secret != '':
+	ice.getImplicitContext().put("secret", secret)
 meta = Murmur.MetaPrx.checkedCast(proxy)
 
 # Load route endpoints

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -26,10 +26,19 @@ auth = HTTPDigestAuth()
 # If enabled, all endpoints will be digest auth protected
 auth_enabled = settings.ENABLE_AUTH
 
-# Load up Murmur slice file into Ice and create connection
+# Load up Murmur slice file into Ice
 Ice.loadSlice('', ['-I' + Ice.getSliceDir(), os.path.join(settings.MURMUR_ROOT, settings.SLICE_FILE)])
 import Murmur
-ice = Ice.initialize()
+
+# Configure Ice properties
+props = Ice.createProperties()
+props.setProperty("Ice.ImplicitContext", "Shared")
+props.setProperty('Ice.Default.EncodingVersion', '1.0')
+idata = Ice.InitializationData()
+idata.properties = props
+
+# Create Ice connection
+ice = Ice.initialize(idata)
 proxy = ice.stringToProxy(settings.ICE_HOST.encode('ascii'))
 meta = Murmur.MetaPrx.checkedCast(proxy)
 

--- a/settings.py
+++ b/settings.py
@@ -16,6 +16,7 @@ APP_DEBUG = True
 
 # Ice connectivity
 ICE_HOST = 'Meta:tcp -h localhost -p 6502'
+ICE_SECRET = ''
 SLICE_FILE = 'Murmur.ice'
 
 # Default path of application


### PR DESCRIPTION
Ice properties needed to be added so I could force encoding, otherwise my Ice 3.5 client couldn't connect to a static Linux server. While I was there, I added rudimentary support for using an Ice secret, just because it's about three lines, mostly just copied from mice.py in the Murmur source tree.

I'm not entirely sure that encoding the secret to ASCII is correct, as I believe Mumble supports UTF-8 in secrets. I'll investigate that and change it later.

We could probably add support for a read secret as well for better privsep, but I don't think it's necessary at the moment - if someone owns the REST endpoint the administrator probably has bigger problems - and it'd make things much more complicated.