### PR TITLE
Make POST /servers/ return the server object instead of just the id.

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -132,12 +132,7 @@ class ServersView(FlaskView):
         # Start server
         server.start()
 
-        # Format to JSON
-        json_data = {
-            'id': server.id()
-        }
-
-        return jsonify(json_data)
+        return self.get(server.id())
 
     @conditional(auth.login_required, auth_enabled)
     def delete(self, id):


### PR DESCRIPTION
Instead of just returning the ID of the new server, pass it along to the get() function instead so we return all the details. In my use case, it saves an extra RPC call.