### PR TITLE
Add configurable Ice.MessageSizeMax property to settings.py

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -34,6 +34,7 @@ import Murmur
 props = Ice.createProperties()
 props.setProperty("Ice.ImplicitContext", "Shared")
 props.setProperty('Ice.Default.EncodingVersion', '1.0')
+props.setProperty('Ice.MessageSizeMax', str(settings.ICE_MESSAGESIZE))
 idata = Ice.InitializationData()
 idata.properties = props
 

--- a/settings.py.example
+++ b/settings.py.example
@@ -17,6 +17,7 @@ APP_DEBUG = True
 # Ice connectivity
 ICE_HOST = 'Meta:tcp -h localhost -p 6502'
 ICE_SECRET = ''
+ICE_MESSAGESIZE = 1024 # in KB - Ice default is 1024KB which is 1MB
 SLICE_FILE = 'Murmur.ice'
 
 # Default path of application


### PR DESCRIPTION
The default of 1MB (Ice.MessageSizeMax = 1024) is not big enough for
meta.getAllServers() response on a busy server host, so allow users to
configure it in `settings.py`.

It corresponds to this section in Murmur.ini (Murmur ships with 64MB):

```ini
[Ice]
Ice.MessageSizeMax=65536
```