### PR TITLE
Add CVP view.

### DIFF
--- a/app/cvp.py
+++ b/app/cvp.py
@@ -1,0 +1,40 @@
+"""
+cvp.py
+Functions for generating CVP feeds.
+
+:copyright: (C) 2014 by github.com/alfg.
+:license:   MIT, see README for more details.
+"""
+
+def cvp_player_to_dict(player):
+    """
+    Convert a player object from a Tree to a CVP-compliant dict.
+    """
+    return {
+        "session": player.session,
+        "userid": player.userid,
+        "name": player.name,
+        "deaf": player.deaf,
+        "mute": player.mute,
+        "selfDeaf": player.selfDeaf,
+        "selfMute": player.selfMute,
+        "suppress": player.suppress,
+        "onlinesecs": player.onlinesecs,
+        "idlesecs": player.idlesecs
+    }
+
+def cvp_chan_to_dict(channel):
+    """
+    Convert a channel from a Tree object to a CVP-compliant dict, recursively.
+    """
+    return {
+        "id": channel.c.id,
+        "parent": channel.c.parent,
+        "name": channel.c.name,
+        "description": channel.c.description,
+        "channels": [ cvp_chan_to_dict(c) for c in channel.children ],
+        "users": [ cvp_player_to_dict(p) for p in channel.users ],
+        "position": channel.c.position,
+        "temporary": channel.c.temporary,
+        "links": channel.c.links
+    }

--- a/app/utils.py
+++ b/app/utils.py
@@ -6,6 +6,9 @@ Utilities used within the application.
 :license:   MIT, see README for more details.
 """
 
+from flask import request, current_app
+from functools import wraps
+
 from settings import USERS as users
 from app import auth
 
@@ -83,3 +86,18 @@ def get_all_users_count(meta):
     for s in meta.getAllServers():
         user_count += (s.isRunning() and len(s.getUsers())) or 0
     return user_count
+
+def support_jsonp(f):
+    """
+    Wraps JSONified output for JSONP
+    Copied from https://gist.github.com/aisipos/1094140
+    """
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        callback = request.args.get('callback', False)
+        if callback:
+            content = str(callback) + '(' + str(f(*args,**kwargs).data) + ')'
+            return current_app.response_class(content, mimetype='application/javascript')
+        else:
+            return f(*args, **kwargs)
+    return decorated_function


### PR DESCRIPTION
This was pretty much copy+pasted from MumbleDog's internal service, with
a few changes. It currently doesn't require authentication, even if
ENABLE_AUTH = True in settings.py, as CVP is normally public.

Uses the same JSONP wrapper/decorator as guildbit.

Thanks to @alfg for pointing it out, I copied the decorator from guildbit,
which was itself copied from https://gist.github.com/aisipos/1094140

Using the accepted[by whom?] standard of prefixing custom configuration
variables with 'x_', CVP is only enabled for servers where x_cvp is "true",
per Python boolean truth standards.