### PR TITLE
Add a list users API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Murmur-REST is still in early development. If you find any issues or would like 
 
 | Endpoint | Description |
 | ---- | --------------- |
+| GET /servers/:serverid/user | Get all users in a server |
 | GET /servers/:serverid/user/:userid | Get User |
 | POST /servers/:serverid/user | Create User, formdata:  username&password |
 | DELETE /servers/:serverid/user/:userid | Delete User |

--- a/app/api.py
+++ b/app/api.py
@@ -324,6 +324,21 @@ class ServersView(FlaskView):
         }
         return Response(json.dumps(json_data, sort_keys=True, indent=4), mimetype='application/json')
 
+    @route('<id>/user', methods=['GET'])
+    def users(self, id):
+        """ Gets all users on server
+        """
+
+        server = meta.getServer(int(id))
+
+        # Return 404 if not found
+        if server is None:
+            return jsonify(message="Not Found"), 404
+
+        data = obj_to_dict(server.getUsers())
+
+        return Response(json.dumps(data, sort_keys=True, indent=4), mimetype='application/json')
+
     @conditional(auth.login_required, auth_enabled)
     @route('<id>/channels', methods=['GET'])
     def channels(self, id):
@@ -573,4 +588,3 @@ CVPView.register(app)
 
 if __name__ == '__main__':
     app.run(debug=True)
-


### PR DESCRIPTION
An API call to get the list of users on a server was something I needed but was not implemented. I've gone ahead an added it in the same style as the channels method directly below it. 

I tested it on my fork and everything seems to work as expected, though if there is a test suite I don't know about please let me know and I'll add them.