### PR TITLE
Mute and unmute a user via the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Murmur-REST is still in early development. If you find any issues or would like 
 | POST /servers/:serverid/user | Create User, formdata:  username&password |
 | DELETE /servers/:serverid/user/:userid | Delete User |
 | POST /servers/:serverid/kickuser?usersession=1 | Kick user with session #1 |
+| POST /servers/:serverid/user/:userid/mute | Mute User |
+| POST /servers/:serverid/user/:userid/unmute | Unmute User |
 
 #### Channels
 

--- a/app/api.py
+++ b/app/api.py
@@ -622,7 +622,7 @@ class ServersView(FlaskView):
         #       Find a better way to get a user by userid from mumble
         try:
             return [u for u in server.getUsers().values() if u.userid == int(userid)][0]
-        except ValueError:
+        except ValueError, IndexError:
             return None
 
 


### PR DESCRIPTION
This pull requests allows users to be muted and unmuted (or suppressed in Mumur parlance) via the API.   When a user is muted in this way they are cannot be heard by users on the server nor can they unmute themselves via the client. This only works for users that are currently online.

It should be noted that the `get_users` method here isn't an ideal implementation and will not scale well for large numbers of concurrent users. From digging through the documentation I could not find an API method for getting a single user via userid. Everything relies on sessionid which is temporary and, at least in my application, not useful. Thus, in order to get a user by userid we loop through all the users that are online and pick out the one with the corresponding id. Again, not ideal, but at least for my uses it worked and was necessary to provide this functionality.

If there is a better way of accomplishing this functionality I'm all 👂 👂 . In the meantime, these methods seem like they'd be useful for other people.