### PR TITLE
fix: allow for no users in the settings

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -10,22 +10,22 @@ All default settings. No configuration required, unless you want to enable diges
 import os
 
 # Settings for running a local dev server with runserver.py
-APP_HOST = os.environ.get('APP_HOST', '0.0.0.0')
-APP_PORT = os.environ.get('APP_PORT', 8080)
-APP_DEBUG = os.environ.get('APP_DEBUG') == 'True'
+APP_HOST = os.environ.get("APP_HOST", "0.0.0.0")
+APP_PORT = os.environ.get("APP_PORT", 8080)
+APP_DEBUG = os.environ.get("APP_DEBUG") == "True"
 
 # Ice connectivity
-ICE_HOST = 'Meta:tcp -h localhost -p 6502'
-ICE_SECRET = os.environ.get('ICE_SECRET', '')
-ICE_MESSAGESIZE = 1024 # in KB - Ice default is 1024KB which is 1MB
-SLICE_FILE = 'Murmur.ice'
+ICE_HOST = "Meta:tcp -h localhost -p 6502"
+ICE_SECRET = os.environ.get("ICE_SECRET", "")
+ICE_MESSAGESIZE = 1024  # in KB - Ice default is 1024KB which is 1MB
+SLICE_FILE = "Murmur.ice"
 
 # Default path of application
 MURMUR_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 # Digest Authentication. Add users as necessary.
-ENABLE_AUTH = os.environ.get('ENABLE_AUTH') == 'True'
+ENABLE_AUTH = os.environ.get("ENABLE_AUTH") == "True"
 
 # If ENABLE_AUTH enabled, add user credentials below
-users = os.environ.get('USERS', '')
-USERS = dict(item.split(':') for item in users.split(','))
+users = os.environ.get("USERS", "")
+USERS = dict(item.split(":") for item in users.split(",")) if users else dict()


### PR DESCRIPTION
closes #30 

When there is no USERS environment variable or when it is empty, the
application crashed.

Therefore, it have been fixed and when no USERS variable is set or when
the USER variable is empty, an empty dictionnary is created as the user
configuration.